### PR TITLE
Bump version and remove dependabot for API client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: npm
-    directory: '/stable'
-    schedule:
-      interval: weekly
-      time: '00:00'
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: npm
-    directory: '/unstable'
-    schedule:
-      interval: weekly
-      time: '00:00'
-    open-pull-requests-limit: 10

--- a/stable/package.json
+++ b/stable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jellyfin/client-axios",
-  "version": "10.7.6",
+  "version": "10.7.7",
   "description": "Jellyfin API client using axios",
   "author": "Jellyfin Contributors",
   "keywords": [


### PR DESCRIPTION
* Remove dependabot for both API client versions. It's essentially useless, since openapi-generator already updates the versions whenever it's updated and we'll never re-publish a version, since NPM doesn't allow it. So just let the generator handle dependency versions.
* Bumps the stable version to 10.7.7. The 10.7.6 build from 2 months ago miraculously appeared when trying to republish, so we have to bump it manually to actually update with the working client. Since we don't plan to do a 10.7.7, this should be fine.